### PR TITLE
Сохранять заметки в sessionStorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,8 +62,22 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     
     <script>
-        // Массив для хранения заметок
-        let notes = [];
+        // Ключ для хранения заметок в sessionStorage
+        const STORAGE_KEY = 'simple_notes_app_notes';
+        
+        // Функция для загрузки заметок из sessionStorage
+        function loadNotesFromStorage() {
+            const storedNotes = sessionStorage.getItem(STORAGE_KEY);
+            return storedNotes ? JSON.parse(storedNotes) : [];
+        }
+        
+        // Функция для сохранения заметок в sessionStorage
+        function saveNotesToStorage(notes) {
+            sessionStorage.setItem(STORAGE_KEY, JSON.stringify(notes));
+        }
+        
+        // Массив для хранения заметок (загружается из sessionStorage)
+        let notes = loadNotesFromStorage();
         // ID редактируемой заметки (null, если создается новая)
         let editingNoteId = null;
 
@@ -85,6 +99,9 @@
                 const id = Date.now(); // Простой способ создания уникального ID
                 notes.unshift({ id, title, content });
             }
+            
+            // Сохраняем заметки в sessionStorage
+            saveNotesToStorage(notes);
             
             // Очищаем форму
             clearForm();
@@ -118,6 +135,8 @@
         function deleteNote(noteId) {
             if (confirm('Вы уверены, что хотите удалить эту заметку?')) {
                 notes = notes.filter(note => note.id !== noteId);
+                // Сохраняем обновленный массив заметок в sessionStorage
+                saveNotesToStorage(notes);
                 renderNotes();
             }
         }


### PR DESCRIPTION
Основные изменения:

Добавлена константа STORAGE_KEY для ключа хранения в sessionStorage.

Добавлены функции для работы с sessionStorage:

loadNotesFromStorage() - загружает заметки из sessionStorage при загрузке страницы

saveNotesToStorage(notes) - сохраняет массив заметок в sessionStorage

Инициализация массива notes теперь происходит через вызов loadNotesFromStorage(), который:

Пытается получить данные из sessionStorage

Если данные есть - парсит их из JSON

Если данных нет - возвращает пустой массив

Добавлен вызов saveNotesToStorage() в ключевых местах:

После сохранения заметки (создания или редактирования)

После удаления заметки

Теперь заметки сохраняются при обновлении страницы и доступны в течение всей сессии браузера. При закрытии вкладки/браузера данные будут удалены (так работает sessionStorage). Если нужно сохранять заметки на более длительный срок, можно использовать localStorage вместо sessionStorage.