### PR TITLE
Хранить заметки в localStorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,21 +62,21 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     
     <script>
-        // Ключ для хранения заметок в sessionStorage
+        // Ключ для хранения заметок в localStorage
         const STORAGE_KEY = 'simple_notes_app_notes';
         
-        // Функция для загрузки заметок из sessionStorage
+        // Функция для загрузки заметок из localStorage
         function loadNotesFromStorage() {
-            const storedNotes = sessionStorage.getItem(STORAGE_KEY);
+            const storedNotes = localStorage.getItem(STORAGE_KEY);
             return storedNotes ? JSON.parse(storedNotes) : [];
         }
         
-        // Функция для сохранения заметок в sessionStorage
+        // Функция для сохранения заметок в localStorage
         function saveNotesToStorage(notes) {
-            sessionStorage.setItem(STORAGE_KEY, JSON.stringify(notes));
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(notes));
         }
         
-        // Массив для хранения заметок (загружается из sessionStorage)
+        // Массив для хранения заметок (загружается из localStorage)
         let notes = loadNotesFromStorage();
         // ID редактируемой заметки (null, если создается новая)
         let editingNoteId = null;
@@ -100,7 +100,7 @@
                 notes.unshift({ id, title, content });
             }
             
-            // Сохраняем заметки в sessionStorage
+            // Сохраняем заметки в localStorage
             saveNotesToStorage(notes);
             
             // Очищаем форму
@@ -135,7 +135,7 @@
         function deleteNote(noteId) {
             if (confirm('Вы уверены, что хотите удалить эту заметку?')) {
                 notes = notes.filter(note => note.id !== noteId);
-                // Сохраняем обновленный массив заметок в sessionStorage
+                // Сохраняем обновленный массив заметок в localStorage
                 saveNotesToStorage(notes);
                 renderNotes();
             }


### PR DESCRIPTION
Основное изменение - замена sessionStorage на localStorage:

sessionStorage.setItem() → localStorage.setItem()

sessionStorage.getItem() → localStorage.getItem()

Ключевые особенности localStorage:

Данные сохраняются даже после закрытия браузера

Данные доступны при повторном открытии страницы в любое время

Данные не имеют срока действия (остаются до явного удаления)

Ограничение по размеру около 5-10 МБ (в зависимости от браузера)

Теперь заметки будут сохраняться:

При обновлении страницы

При закрытии и повторном открытии браузера

При переходе на другие сайты и возврате обратно

Даже при перезагрузке компьютера (если не очищать кэш браузера)

Все остальные функции (редактирование, удаление, создание заметок) работают так же, как и раньше.